### PR TITLE
Dev 1159 add archiving of collaterals

### DIFF
--- a/config.yml
+++ b/config.yml
@@ -27,4 +27,5 @@ app:
             passwd: !ENV ${MEDIAHAVEN_API_PASSWD}
     organisations-api:
         host: http://do-qas-esb-01.do.viaa.be:10003/api/
-    destination-folder: DISK-SHARE-EVENTS
+    essence-destination-folder: DISK-SHARE-EVENTS
+    collateral-destination-folder: DISK-SHARE-EVENTS

--- a/config.yml.example
+++ b/config.yml.example
@@ -21,6 +21,11 @@ app:
             host: 
             user: !ENV ${MEDIAHAVEN_FTP_USER}
             passwd: !ENV ${MEDIAHAVEN_FTP_PASSWD}
+        api:
+            host:
+            user: 
+            passwd: 
     organisations-api:
         host: 
-    destination-folder: 
+    essence-destination-folder: 
+    collateral-destination-folder:

--- a/main.py
+++ b/main.py
@@ -162,12 +162,16 @@ def callback(ch, method, properties, body, ctx):
         collateral_type = object_key.split("/")[0]
         media_id = object_key.split("/")[1]
 
+        log.debug(f"Received a {collateral_type} for media id: {media_id}")
+
         query_params = [
             ("dc_identifier_localid", media_id),
         ]
         result = mediahaven_service.get_fragment(query_params)
         item_pid = result["MediaDataList"][0]["Dynamic"]["PID"]
         item_fragment_id = result["MediaDataList"][0]["Internal"]["FragmentId"]
+
+        log.debug(f"Found pid: {item_pid} for media id: {media_id}")
         
         pid = f"{item_pid}_{collateral_type}"
         dest_path = construct_destination_path(cp_name, ctx.config.app_cfg['collateral-destination-folder'])
@@ -237,6 +241,8 @@ def main(ctx):
         # Ack the message when the callback fn returns
         auto_ack=True,
     )
+
+    log.info("Started listening for messages...", queue=ctx.config.app_cfg["rabbitmq"]["incoming"])
     channel.start_consuming()
 
 

--- a/meemoo/services.py
+++ b/meemoo/services.py
@@ -184,6 +184,27 @@ class MediahavenService(Service):
 
         return response.json()
 
+        @__authenticate
+    def update_metadata(self, fragment_id: str, sidecar: str) -> dict:
+        headers: dict = self._construct_headers()
+
+        # Construct the URL to POST to
+        url: str = f"{self.config["mediahaven"]["api"]["host"] }/media/{fragment_id}"
+
+        data: dict = {"metadata": sidecar, "reason": "metadataUpdated"}
+
+        # Send the POST request, as multipart/form-data
+        response = requests.post(url, headers=headers, files=data)
+
+        if response.status_code == 401:
+            # AuthenticationException triggers a retry with a new token
+            raise AuthenticationException(response.text)
+
+        # If there is an HTTP error, raise it
+        response.raise_for_status()
+
+        return True
+
 
 # vim modeline
 # vim: tabstop=8 expandtab shiftwidth=4 softtabstop=4

--- a/meemoo/services.py
+++ b/meemoo/services.py
@@ -184,12 +184,12 @@ class MediahavenService(Service):
 
         return response.json()
 
-        @__authenticate
+    @__authenticate
     def update_metadata(self, fragment_id: str, sidecar: str) -> dict:
         headers: dict = self._construct_headers()
 
         # Construct the URL to POST to
-        url: str = f"{self.config["mediahaven"]["api"]["host"] }/media/{fragment_id}"
+        url: str = f"{self.config['mediahaven']['api']['host'] }/media/{fragment_id}"
 
         data: dict = {"metadata": sidecar, "reason": "metadataUpdated"}
 

--- a/tests/resources.py
+++ b/tests/resources.py
@@ -14,7 +14,7 @@
 #
 #######################################################################
 
-S3_MOCK_EVENT = """{  
+S3_MOCK_ESSENCE_EVENT = """{  
    "Records":[
       {  
          "eventVersion":"0.1",
@@ -46,6 +46,51 @@ S3_MOCK_EVENT = """{
             },
             "object":{  
                "key":"191213-VAN___statement_De_ideale_wereld___Don_12_December_2019-1983-d5be522e-3609-417a-a1f4-5922854620c8.MXF",
+               "size":4248725,
+               "eTag":"77930bf06b236e089a22a255e6b28377",
+               "metadata":{
+                  "Type": "application/mxf",
+                  "Castor-System-Cid":"7da76343ad6bc9f2f739f0595a2756e4",
+                  "Content-Md5":"rbyRpD6YijtbdFuFKakLYQ=="
+               }
+            }
+         }
+      }
+   ]
+}"""
+
+S3_MOCK_COLLATERAL_EVENT = """{  
+   "Records":[
+      {  
+         "eventVersion":"0.1",
+         "eventSource":"viaa:s3",
+         "eventTime":"2019-12-12T00:39:15.049Z",
+         "eventName":"ObjectCreated:Put",
+         "userIdentity":{  
+            "principalId":"Object Owner CN+OR-id"
+         },
+         "requestParameters":{  
+            "sourceIPAddress":"54.93.243.153"
+         },
+         "responseElements":{  
+            "x-viaa-request-id":"bb90f87be822889b21f197b43090cb4b"
+         },
+         "s3":{
+            "domain":{
+               "name":"s3"
+            },
+            "bucket":{
+               "name":"mam-collaterals",
+               "ownerIdentity":{
+                  "principalId":"Bucket Owner CN+OR-id"
+               },
+               "metadata":{
+                  "tenant": "OR-rf5kf25",
+                  "kind":"ingest"
+               }
+            },
+            "object":{  
+               "key":"TYPE/MEDIAID/blabla.xif",
                "size":4248725,
                "eTag":"77930bf06b236e089a22a255e6b28377",
                "metadata":{

--- a/tests/test_helpers.py
+++ b/tests/test_helpers.py
@@ -17,12 +17,12 @@
 import json
 import unittest
 from meemoo.helpers import get_from_event
-from tests.resources import S3_MOCK_EVENT
+from tests.resources import S3_MOCK_ESSENCE_EVENT
 
 
 class TestHelperFunctions(unittest.TestCase):
     def test_get_from_event(self):
-        bucket = get_from_event(json.loads(S3_MOCK_EVENT), "bucket")
+        bucket = get_from_event(json.loads(S3_MOCK_ESSENCE_EVENT), "bucket")
         self.assertEqual(bucket, "MAM_HighresVideo")
 
 

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -1,10 +1,10 @@
 import json
 
 import pytest
-from main import callback, construct_mediahaven_external_metadata
+from main import callback, construct_essence_sidecar
 
 from .mocks import mock_events, mock_ftp, mock_organisations_api
-from .resources import S3_MOCK_EVENT, MOCK_MEDIAHAVEN_EXTERNAL_METADATA
+from .resources import S3_MOCK_ESSENCE_EVENT, S3_MOCK_COLLATERAL_EVENT, MOCK_MEDIAHAVEN_EXTERNAL_METADATA
 
 
 class Expando(object):
@@ -23,15 +23,19 @@ def context():
 def test_callback(context, mock_ftp, mock_organisations_api, mock_events):
     ex = Expando()
     ex.correlation_id = "a1b2c3"
-    callback(None, None, ex, S3_MOCK_EVENT, context)
+    callback(None, None, ex, S3_MOCK_ESSENCE_EVENT, context)
 
+def test_callback(context, mock_ftp, mock_organisations_api, mock_events):
+    ex = Expando()
+    ex.correlation_id = "a1b2c3"
+    callback(None, None, ex, S3_MOCK_COLLATERAL_EVENT, context)
 
-def test_construct_mediahaven_external_metadata():
+def test_construct_essence_sidecar():
     # ARRANGE
-    event = json.loads(S3_MOCK_EVENT)
+    event = json.loads(S3_MOCK_ESSENCE_EVENT)
 
     # ACT
-    sidecar_xml = construct_mediahaven_external_metadata(event, "test_pid")
+    sidecar_xml = construct_essence_sidecar(event, "test_pid")
 
     # ASSERT
     assert sidecar_xml.decode("utf-8") == MOCK_MEDIAHAVEN_EXTERNAL_METADATA


### PR DESCRIPTION
Note: we currently only support uploading 1 version of the collateral. If the same type of collateral is received twice for the same media id, it will fail since the external id is already in the archive.