### PR TITLE
DEV-1188 Improve handling of unknown service host

### DIFF
--- a/config.yml
+++ b/config.yml
@@ -21,7 +21,7 @@ app:
             host: ftp://dg-qas-tra-01.dg.viaa.be/
             user: !ENV ${MEDIAHAVEN_FTP_USER}
             passwd: !ENV ${MEDIAHAVEN_FTP_PASSWD}
-        api:
+    mediahaven-api:
             host: https://archief-qas.viaa.be/mediahaven-rest-api/resources/
             user: !ENV ${MEDIAHAVEN_API_USER}
             passwd: !ENV ${MEDIAHAVEN_API_PASSWD}

--- a/meemoo/services.py
+++ b/meemoo/services.py
@@ -50,8 +50,10 @@ class Service(object):
         host = None
         try:
             host = self.config[self.name]["host"]
-        except KeyError as e:
-            log.warning("Oeps")
+        except KeyError:
+            log.warning(
+                f"The key 'host' not found in the config for service: {self.name}"
+            )
         else:
             log.debug(f"Host: {host}")
         return host

--- a/meemoo/services.py
+++ b/meemoo/services.py
@@ -131,9 +131,9 @@ class MediahavenService(Service):
 
     def __get_token(self) -> str:
         """Gets an OAuth token that can be used in mediahaven requests to authenticate."""
-        user: str = self.config["mediahaven"]["api"]["user"]
-        password: str = self.config["mediahaven"]["api"]["passwd"]
-        url: str = self.config["mediahaven"]["api"]["host"] + "oauth/access_token"
+        user: str = self.config[self.name]["user"]
+        password: str = self.config[self.name]["passwd"]
+        url: str = f"{self.host}oauth/access_token"
         payload = {"grant_type": "password"}
 
         try:
@@ -161,7 +161,7 @@ class MediahavenService(Service):
     @__authenticate
     def get_fragment(self, query_params: List[Tuple[str, str]]) -> dict:
         headers: dict = self._construct_headers()
-        url: str = self.config["mediahaven"]["api"]["host"] + "media"
+        url: str = f"{self.host}media"
 
         # Construct URL query parameters as "+(k1:v1 k2:v2)"
         query: str = f"+({' '.join([':'.join(k_v) for k_v in query_params])})"
@@ -191,7 +191,7 @@ class MediahavenService(Service):
         headers: dict = self._construct_headers()
 
         # Construct the URL to POST to
-        url: str = f"{self.config['mediahaven']['api']['host'] }/media/{fragment_id}"
+        url: str = f"{self.host}media/{fragment_id}"
 
         data: dict = {"metadata": sidecar, "reason": "metadataUpdated"}
 

--- a/tests/test_services.py
+++ b/tests/test_services.py
@@ -1,0 +1,28 @@
+import pytest
+
+from meemoo.services import Service
+
+
+class TestUnknownHostService(Service):
+    def __init__(self, ctx):
+        self.name = "unknown"
+        super().__init__(ctx)
+
+
+@pytest.fixture
+def context():
+    from viaa.configuration import ConfigParser
+    from meemoo.context import Context
+
+    config = ConfigParser()
+    return Context(config)
+
+
+def test_get_service_host_not_found(context, caplog):
+    service = TestUnknownHostService(context)
+    assert service.host is None
+    log_record = caplog.records[0]
+    assert log_record.levelname == "WARNING"
+    assert log_record.message == (
+        "The key 'host' not found in the config for service: unknown"
+    )


### PR DESCRIPTION
The host of a service is defined by the name of said service in the
sense that the name is used to look up the host in the config.yml.
If that field, based on the service name, is not found in the config
file, it logged a warning that wasn't very useful. This has been
expanded so that it also logs the service name.

Also fixed the host config for "mediahaven-api".