### PR TITLE
DEV-1191 Mock MediaHaven API calls for testing

### DIFF
--- a/tests/mocks.py
+++ b/tests/mocks.py
@@ -42,3 +42,28 @@ def mock_events(monkeypatch):
 
     monkeypatch.setattr(Events, "__init__", mock_init)
     monkeypatch.setattr(Events, "publish", mock_publish)
+
+
+@pytest.fixture
+def mock_mediahaven_api(monkeypatch):
+    def mock_get_token(self):
+        print("Getting token.")
+        return {"access_token": "bearer, bear with me"}
+
+    def mock_get_fragment(self, query_params):
+        print("Get fragment")
+        return {
+            "MediaDataList": [
+                {"Dynamic": {"PID": "pid"}, "Internal": {"FragmentId": "ID"}}
+            ]
+        }
+
+    def mock_update_metadata(self, fragment_id: str, sidecar: str):
+        print("Update metadata")
+        pass
+
+    from meemoo.services import MediahavenService
+
+    monkeypatch.setattr(MediahavenService, "_MediahavenService__get_token", mock_get_token)
+    monkeypatch.setattr(MediahavenService, "get_fragment", mock_get_fragment)
+    monkeypatch.setattr(MediahavenService, "update_metadata", mock_update_metadata)

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -3,8 +3,12 @@ import json
 import pytest
 from main import callback, construct_essence_sidecar
 
-from .mocks import mock_events, mock_ftp, mock_organisations_api
-from .resources import S3_MOCK_ESSENCE_EVENT, S3_MOCK_COLLATERAL_EVENT, MOCK_MEDIAHAVEN_EXTERNAL_METADATA
+from .mocks import mock_events, mock_ftp, mock_organisations_api, mock_mediahaven_api
+from .resources import (
+    S3_MOCK_ESSENCE_EVENT,
+    S3_MOCK_COLLATERAL_EVENT,
+    MOCK_MEDIAHAVEN_EXTERNAL_METADATA
+)
 
 
 class Expando(object):
@@ -20,15 +24,19 @@ def context():
     return Context(config)
 
 
-def test_callback(context, mock_ftp, mock_organisations_api, mock_events):
+@pytest.mark.parametrize("body", [S3_MOCK_ESSENCE_EVENT, S3_MOCK_COLLATERAL_EVENT])
+def test_callback(
+    body,
+    context,
+    mock_ftp,
+    mock_organisations_api,
+    mock_events,
+    mock_mediahaven_api
+):
     ex = Expando()
     ex.correlation_id = "a1b2c3"
-    callback(None, None, ex, S3_MOCK_ESSENCE_EVENT, context)
+    callback(None, None, ex, body, context)
 
-def test_callback(context, mock_ftp, mock_organisations_api, mock_events):
-    ex = Expando()
-    ex.correlation_id = "a1b2c3"
-    callback(None, None, ex, S3_MOCK_COLLATERAL_EVENT, context)
 
 def test_construct_essence_sidecar():
     # ARRANGE


### PR DESCRIPTION
Also, parametrize the two tests in `test_main.py` with the same name
so that they both run.