### PR TITLE
DEV-1297 Cache CP name

### DIFF
--- a/main.py
+++ b/main.py
@@ -34,6 +34,7 @@ from viaa.observability import logging
 
 config = ConfigParser()
 log = logging.get_logger(__name__, config=config)
+cp_names = {}
 
 
 def construct_destination_path(cp_name, folder):
@@ -128,6 +129,28 @@ def construct_fragment_update_sidecar(pid):
     )
 
 
+def get_cp_name(or_id: str, ctx: Context) -> str:
+    """ Retrieves the CP MAM Name for a given OR ID.
+
+    The mapping between the OR ID and the CP MAM Name is cached.
+    If the mapping is not found, The organisations API will be queried to retrieve
+    that information. That information will be cached in a dictionary.
+
+    Arguments:
+        or_id {str} -- The OR ID
+        ctx {Context} -- The context
+    Returns:
+        str -- The CP MAM Name
+    """
+    if or_id in cp_names:
+        cp_name = cp_names[or_id]
+    else:
+        org_service = OrganisationsService(ctx)
+        cp_name = org_service.get_organisation(or_id)["cp_name_mam"]
+        cp_names[or_id] = cp_name
+    return cp_name
+
+
 def handle_create_event(event: dict, properties, ctx: Context) -> bool:
     """Handler for s3 create events"""
     # Check if item already in mediahaven based on key and md5
@@ -145,8 +168,7 @@ def handle_create_event(event: dict, properties, ctx: Context) -> bool:
         return True
 
     or_id = get_from_event(event, "tenant")
-    org_service = OrganisationsService(ctx)
-    cp_name = org_service.get_organisation(or_id)["cp_name_mam"]
+    cp_name = get_cp_name(or_id, ctx)
 
     # Check if we are dealing with essence or collateral
     bucket = get_from_event(event, "bucket")

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -1,7 +1,7 @@
 import json
 
 import pytest
-from main import callback, construct_essence_sidecar
+from main import callback, construct_essence_sidecar, cp_names, get_cp_name
 
 from .mocks import mock_events, mock_ftp, mock_organisations_api, mock_mediahaven_api
 from .resources import (
@@ -70,3 +70,21 @@ def test_construct_essence_sidecar():
 
     # ASSERT
     assert sidecar_xml.decode("utf-8") == MOCK_MEDIAHAVEN_EXTERNAL_METADATA
+
+
+def test_get_cp_name(context, mock_organisations_api):
+    or_id = "or_id"
+    assert or_id not in cp_names
+    name = get_cp_name("or_id", context)
+    assert name == "UNITTEST"
+    assert cp_names["or_id"] == name
+
+
+def test_get_cp_name_cached(context, mock_organisations_api):
+    or_id = "or_id_cached"
+    assert or_id not in cp_names
+    cp_name = "CP MAM NAME"
+    cp_names["or_id"] = cp_name
+    name = get_cp_name("or_id", context)
+    assert name != "UNITTEST"
+    assert name == cp_name


### PR DESCRIPTION
In the case of a create event, the Organisations API will be queried to
return the CP MAM Name for a given OR-ID. This CP MAM Name won't change
often and it will also be a small set of OR-IDs that will be potentially
queried. Sending out this call for every event is bit wasteful. We will
now cache this information after a successful call to the Organisations
API.