### PR TITLE
DEV-1215 Replace auto-ack mechanism

### DIFF
--- a/meemoo/helpers.py
+++ b/meemoo/helpers.py
@@ -163,7 +163,7 @@ class FTP(object):
             conn = BuiltinFTP(host=self.host, user=ftp_user, passwd=ftp_passwd)
         except Exception as e:
             log.error(e)
-            raise
+            raise e
         else:
             log.debug(f"Succesfully established connection to {self.host}")
             return conn
@@ -177,8 +177,9 @@ class FTP(object):
                 conn.cwd(destination_path)
                 stor_cmd = f"STOR {destination_filename}"
                 conn.storbinary(stor_cmd, BytesIO(content_bytes))
-            except Exception:
+            except Exception as e:
                 log.critical(f"Failed to put sidecar on {self.host} {destination_path}")
+                raise e
 
 
 # vim modeline

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -1,4 +1,5 @@
 import json
+from unittest.mock import MagicMock
 
 import pytest
 from main import callback, construct_essence_sidecar
@@ -44,7 +45,10 @@ def test_callback(
 ):
     ex = Expando()
     ex.correlation_id = "a1b2c3"
-    assert callback(None, None, ex, body, context)
+    channel_mock = MagicMock()
+    callback(channel_mock, MagicMock(), ex, body, context)
+    assert channel_mock.basic_ack.call_count == 1
+    assert not channel_mock.basic_nack.call_count
 
 
 @pytest.mark.parametrize("body", [S3_MOCK_UNKNOWN_EVENT, ])
@@ -58,7 +62,10 @@ def test_callback_unsuccessful(
 ):
     ex = Expando()
     ex.correlation_id = "a1b2c3"
-    assert not callback(None, None, ex, body, context)
+    channel_mock = MagicMock()
+    callback(channel_mock, MagicMock(), ex, body, context)
+    assert channel_mock.basic_nack.call_count == 1
+    assert not channel_mock.basic_ack.call_count
 
 
 def test_construct_essence_sidecar():


### PR DESCRIPTION
When using the auto-ack mechanism, a message is considered to be
successfully delivered immediately after it is sent. Even if the
processing of the message would fail, the message will be acked.

We'll send out a manual ack after the message has been successfully
processed. In the case an error happens, a nack will be send. This also
allows for dead-letter functionality.