### PR TITLE
DEV-1454 Remove double double-quotes

### DIFF
--- a/main.py
+++ b/main.py
@@ -190,7 +190,7 @@ def handle_create_event(event: dict, properties, ctx: Context) -> bool:
     # Check if item already in mediahaven based on key and md5
     mediahaven_service = MediahavenService(ctx)
     query_params = [
-        ("s3_object_key", f'"{get_from_event(event, "object_key")}"'),
+        ("s3_object_key", get_from_event(event, "object_key")),
         ("md5", get_from_event(event, "md5")),
     ]
 
@@ -398,8 +398,8 @@ def handle_remove_event(event: dict, properties, ctx: Context) -> bool:
     s3_bucket = get_from_event(event, "bucket")
     s3_object_key = get_from_event(event, "object_key")
     query_params = [
-        ("s3_object_key", f'"{s3_object_key}"'),
-        ("s3_bucket", f'"{s3_bucket}"'),
+        ("s3_object_key", s3_object_key),
+        ("s3_bucket", s3_bucket),
     ]
     try:
         result = mediahaven_service.get_fragment(query_params, or_params=False)

--- a/main.py
+++ b/main.py
@@ -444,7 +444,7 @@ def handle_remove_event(event: dict, properties, ctx: Context) -> bool:
     if fragments:
         # Query all the objects with the media IDs of the fragments
         query_params_media_ids = [
-            ("dc_identifier_localid", f"{media_id}") for media_id in fragments.keys()
+            ("dc_identifier_localid", media_id) for media_id in fragments.keys()
         ]
         try:
             response = mediahaven_service.get_fragment(query_params_media_ids)


### PR DESCRIPTION
The MediaHaven service puts the query values between double quotes itself.
In some cases, the param values were put between double quotes before calling
the MediaHaven service resulting in double double-quotes. The result of that
query is unreliable and thus incorrect.