### PR TITLE
DEV-1574 Remove MD5 check for VRT

### DIFF
--- a/main.py
+++ b/main.py
@@ -211,7 +211,9 @@ def query_params_item_ingested(event: dict, cp_name: str) -> List[Tuple[str, str
     # Check based on the S3 object key
     query_params = [("s3_object_key", get_from_event(event, "object_key"))]
 
-    # Check based on md5 if the md5 is available and the CP is not VRT
+    # Check based on md5 if:
+    #  - the md5 is available and
+    #  - the CP is not VRT unless the item is a collateral
     md5 = get_from_event(event, "md5")
     if md5 and (cp_name.upper() not in ("VRT") or is_collateral(event)):
         query_params.append(("md5", md5))

--- a/main.py
+++ b/main.py
@@ -20,6 +20,7 @@ import json
 import os
 import time
 import re
+from typing import List, Tuple
 
 # 3d party imports
 from lxml import etree
@@ -196,14 +197,36 @@ def get_cp_name(or_id: str, ctx: Context) -> str:
     return cp_name
 
 
+def query_params_item_ingested(event: dict, cp_name: str) -> List[Tuple[str, str]]:
+    """ Construct the query parameters to check if an item is already in the MAM.
+
+    A check on S3 object key is always needed.
+    A check on md5 is only executed if there is an md5 and if the CP is not VRT.
+
+    Returns:
+        List[Tuple[str, str]] -- The query params.
+    """
+    # Check based on the S3 object key
+    query_params = [("s3_object_key", get_from_event(event, "object_key"))]
+
+    # Check based on md5 if the md5 is available and the CP is not VRT
+    md5 = get_from_event(event, "md5")
+    if md5 and cp_name.upper() not in ("VRT"):
+        query_params.append(("md5", md5))
+
+    return query_params
+
+
 def handle_create_event(event: dict, properties, ctx: Context) -> bool:
     """Handler for s3 create events"""
-    # Check if item already in mediahaven based on key and md5
+
+    # Get cp_name for or_id
+    or_id = get_from_event(event, "tenant")
+    cp_name = get_cp_name(or_id, ctx)
+
+    # Check if item already in mediahaven
     mediahaven_service = MediahavenService(ctx)
-    query_params = [
-        ("s3_object_key", get_from_event(event, "object_key")),
-        ("md5", get_from_event(event, "md5")),
-    ]
+    query_params = query_params_item_ingested(event, cp_name)
 
     try:
         result = mediahaven_service.get_fragment(query_params)
@@ -226,10 +249,6 @@ def handle_create_event(event: dict, properties, ctx: Context) -> bool:
             "Item already archived", s3_object_key=get_from_event(event, "object_key")
         )
         return
-
-    # Get cp_name for or_id
-    or_id = get_from_event(event, "tenant")
-    cp_name = get_cp_name(or_id, ctx)
 
     # Check if we are dealing with essence or collateral
     bucket = get_from_event(event, "bucket")

--- a/meemoo/helpers.py
+++ b/meemoo/helpers.py
@@ -61,9 +61,7 @@ def try_to_find_md5(object_metadata):
     Args:
         object_metadata (dict): The object metadata sub-section of the S3-event.
     Returns:
-        str: The md5sum when found.
-    Raises:
-        KeyError: The md5sum was not found or is syntactically incorrect.
+        str: The md5sum when found, an empty string otherwise.
     """
     POSSIBLE_KEYS = ["x-md5sum-meta", "md5sum", "x-amz-meta-md5sum"]
     md5 = ""

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -129,14 +129,26 @@ def test_get_cp_name_cached(context, mock_organisations_api):
     assert name == cp_name
 
 
-def test_query_params_item_ingested(context, mock_organisations_api):
+def test_query_params_item_ingested():
     event = json.loads(S3_MOCK_ESSENCE_EVENT)
-    cp_name = "cp"
-    params = query_params_item_ingested(event, cp_name)
+    params = query_params_item_ingested(event, "cp")
     assert params == [
         (
             "s3_object_key",
             "191213-VAN___statement_De_ideale_wereld___Don_12_December_2019-1983-d5be522e-3609-417a-a1f4-5922854620c8.MXF",
+        ),
+        ("md5", "1234abcd1234abcd1234abcd1234abcd"),
+    ]
+
+@pytest.mark.parametrize("cp", ["cp", "VRT"])
+def test_query_params_item_ingested_collateral(cp):
+    """The item is a collateral, so check on md5 regardless of CP"""
+    event = json.loads(S3_MOCK_COLLATERAL_EVENT)
+    params = query_params_item_ingested(event, cp)
+    assert params == [
+        (
+            "s3_object_key",
+            "TYPE/MEDIAID/blabla.xif",
         ),
         ("md5", "1234abcd1234abcd1234abcd1234abcd"),
     ]
@@ -151,7 +163,7 @@ def test_query_params_item_ingested(context, mock_organisations_api):
     ],
 )
 def test_query_params_item_ingested_no_md5(cp, body):
-    event = json.loads(S3_MOCK_ESSENCE_EVENT_WITHOUT_MD5)
+    event = json.loads(body)
     params = query_params_item_ingested(event, cp)
     assert params == [
         (

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -9,7 +9,8 @@ from main import (
         construct_fragment_update_sidecar,
         cp_names,
         get_cp_name,
-        NackException
+        NackException,
+        query_params_item_ingested,
 )
 from .mocks import mock_events, mock_ftp, mock_organisations_api, mock_mediahaven_api
 from .resources import (
@@ -17,6 +18,7 @@ from .resources import (
     S3_MOCK_COLLATERAL_EVENT,
     S3_MOCK_REMOVED_EVENT,
     S3_MOCK_UNKNOWN_EVENT,
+    S3_MOCK_ESSENCE_EVENT_WITHOUT_MD5,
     MOCK_MEDIAHAVEN_EXTERNAL_METADATA,
     MOCK_MEDIAHAVEN_EXTERNAL_METADATA_COLLATERAL,
     MOCK_MEDIAHAVEN_FRAGMENT_UPDATE,
@@ -126,8 +128,34 @@ def test_get_cp_name_cached(context, mock_organisations_api):
     assert name != "UNITTEST"
     assert name == cp_name
 
-def test_get_cp_name_none(context, mock_organisations_api):
-    or_id = "or_id_none"
-    assert or_id not in cp_names
-    with pytest.raises(NackException) as exception_info:
-        name = get_cp_name(or_id, context)
+
+def test_query_params_item_ingested(context, mock_organisations_api):
+    event = json.loads(S3_MOCK_ESSENCE_EVENT)
+    cp_name = "cp"
+    params = query_params_item_ingested(event, cp_name)
+    assert params == [
+        (
+            "s3_object_key",
+            "191213-VAN___statement_De_ideale_wereld___Don_12_December_2019-1983-d5be522e-3609-417a-a1f4-5922854620c8.MXF",
+        ),
+        ("md5", "1234abcd1234abcd1234abcd1234abcd"),
+    ]
+
+
+@pytest.mark.parametrize(
+    "cp, body",
+    [
+        ("cp", S3_MOCK_ESSENCE_EVENT_WITHOUT_MD5),
+        ("VRT", S3_MOCK_ESSENCE_EVENT),
+        ("VRT", S3_MOCK_ESSENCE_EVENT_WITHOUT_MD5),
+    ],
+)
+def test_query_params_item_ingested_no_md5(cp, body):
+    event = json.loads(S3_MOCK_ESSENCE_EVENT_WITHOUT_MD5)
+    params = query_params_item_ingested(event, cp)
+    assert params == [
+        (
+            "s3_object_key",
+            "191213-VAN___statement_De_ideale_wereld___Don_12_December_2019-1983-d5be522e-3609-417a-a1f4-5922854620c8.MXF",
+        )
+    ]


### PR DESCRIPTION
For VRT it is allowed to ingest multiple files with the same MD5 value.
Remove checking if the file is already ingested in MediaHaven based on
the MD5.